### PR TITLE
Some spanish format mappings bad replacements

### DIFF
--- a/lib/date_picker/form_tag_helper.rb
+++ b/lib/date_picker/form_tag_helper.rb
@@ -174,9 +174,8 @@ module DatePicker
         # Get picker patterns
         values = keys.map{ |key| mapping[key] }
         # Escape any special characters of picker format not preceded by %
-        picker_format.gsub!(/(?<!%)(#{(values.map { |string| Regexp.escape(string) }).join('|')})/i, replace)
         # Escape strftime patterns not preceded by %
-        picker_format.gsub!(/(?<!%)(#{(keys.map { |string| Regexp.escape(string) }).join('|')})/i, replace)
+        picker_format.gsub!(/(?<!%)(#{((keys+values).uniq.map { |string| Regexp.escape(string) }).join('|')})/i, replace)
       end
       
       # If time_zone option is specified, replace timezone identifier with mapping in format


### PR DESCRIPTION
In some spanish date formats, ex :default is '%a, %d de %B de %Y' picker_format is "ddd, DD [[d]][e] MMMM [[d]][e] YYYY", and should be "ddd, DD [d][e] MMMM [d][e] YYYY"